### PR TITLE
Fixed Pulse Tab SinZap function bug

### DIFF
--- a/NM_Configurations.ipf
+++ b/NM_Configurations.ipf
@@ -629,7 +629,7 @@ Function NMConfigOpen( file [ history, quiet ] )
 		
 	else
 	
-		NMDoAlert( "Open File Error: file is not a NeuroMatic configuration file." )
+		NMDoAlert( "Open File Error: file is not a NeuroMatic configuration file: " + file )
 		
 	endif
 	

--- a/NM_Main.ipf
+++ b/NM_Main.ipf
@@ -49,7 +49,7 @@
 //****************************************************************
 
 StrConstant NMPackage = "NeuroMatic"
-StrConstant NMVersionStr = "3.0r"
+StrConstant NMVersionStr = "3.0s"
 Static StrConstant NMHTTP = "http://www.neuromatic.thinkrandom.com/"
 Static StrConstant NMRights = "Copyright (c) 2024 The Silver Lab, UCL"
 Static StrConstant NMEmail = "Jason@ThinkRandom.com"


### PR DESCRIPTION
The linear sine zap/sweep function was missing a factor of 2. This bug created a sweep function that ended with a frequency half what it should have been. Also, the window over which the zap/sweep was computed was incorrect. This was changed to aow.width. Added new "type" parameter which allows one to choose between a linear sweep (type=0) and exponential sweep (type=1).